### PR TITLE
Refactor plugin structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # theia-frontend-plugin
 
-This sample plaugin demonstrates all the available plugin API.
+This sample plagin demonstrates all the available plugin API.
 Examples of usage of each group separated in corresponding file.
 
-Each sample command name starts from common prefix, and if a command result is shown in developers console it has suffix in its name. Also all event lesteners print massages into developers console.
+Each sample command name starts from common prefix, and if a command result is shown in developers console it has suffix in its name. Also all event listeners print messages into developers console.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 [![Build Status](https://travis-ci.org/theia-demo-plugins/theia-frontend-plugin.svg?branch=master)](https://travis-ci.org/theia-demo-plugins/theia-frontend-plugin)
 
 # theia-frontend-plugin
+
+This sample plaugin demonstrates all the available plugin API.
+Examples of usage of each group separated in corresponding file.
+
+Each sample command name starts from common prefix, and if a command result is shown in developers console it has suffix in its name. Also all event lesteners print massages into developers console.

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -9,6 +9,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
- export const COMMAND_NAME_PREFIX = 'Demo: ';
- export const CONSOLE_OUTPUT_COMMAND_SUFIX = ' (console)';
- export const CONSOLE_OUTPUT_PREFIX = '>>>> ';
+export const PLUGIN_NAME = 'theia-frontend-plugin-';
+export const COMMAND_NAME_PREFIX = 'Demo: ';
+export const CONSOLE_OUTPUT_COMMAND_SUFIX = ' (console)';
+export const CONSOLE_OUTPUT_PREFIX = '>>>> ';

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+ export const COMMAND_NAME_PREFIX = 'Demo: ';
+ export const CONSOLE_OUTPUT_COMMAND_SUFIX = ' (console)';
+ export const CONSOLE_OUTPUT_PREFIX = '>>>> ';

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -10,7 +10,7 @@
  */
 
 import * as theia from '@wiptheia/plugin';
-import { CONSOLE_OUTPUT_PREFIX, COMMAND_NAME_PREFIX } from './common/constants';
+import { CONSOLE_OUTPUT_PREFIX, COMMAND_NAME_PREFIX, PLUGIN_NAME } from './common/constants';
 
 export function initEditorsCommands(disposables: theia.Disposable[]) {
 
@@ -52,7 +52,8 @@ export function initEditorsCommands(disposables: theia.Disposable[]) {
         console.log(CONSOLE_OUTPUT_PREFIX, `Text Editor: ${e.textEditor.document.uri} visible ranges: ${JSON.stringify(e.visibleRanges)}`);
     }));
 
-    disposables.push(theia.commands.registerCommand({id: "change editor",label: COMMAND_NAME_PREFIX + "Select Editor Cursor"}, () => {
+    disposables.push(theia.commands.registerCommand(
+        { id: PLUGIN_NAME + 'change editor', label: COMMAND_NAME_PREFIX + 'Select Editor Cursor' }, () => {
         theia.window.showQuickPick(["Block","BlockOutline", "Line", "Underline", "LineThin", "UnderlineThin" ],{placeHolder:"Select Cursor"}).then((c: string| undefined) =>{
             let cursorStyle: theia.TextEditorCursorStyle = theia.TextEditorCursorStyle.Line;
             switch(c!){
@@ -79,11 +80,13 @@ export function initEditorsCommands(disposables: theia.Disposable[]) {
         });
     }));
 
-    disposables.push(theia.commands.registerCommand({id: 'reveal range test', label: COMMAND_NAME_PREFIX + 'Test Reveal Range'}, () => {
+    disposables.push(theia.commands.registerCommand({
+        id: PLUGIN_NAME + 'reveal range test', label: COMMAND_NAME_PREFIX + 'Test Reveal Range'}, () => {
         theia.window.activeTextEditor!.revealRange(new theia.Range(new theia.Position(32, 4), new theia.Position(34,0)), theia.TextEditorRevealType.InCenter);
     }));
 
-    disposables.push(theia.commands.registerCommand({id:'test editor edit',label: COMMAND_NAME_PREFIX + 'Test EditorEdit'}, () => {
+    disposables.push(theia.commands.registerCommand(
+        { id: PLUGIN_NAME + 'test editor edit', label: COMMAND_NAME_PREFIX + 'Test EditorEdit' }, () => {
         const editor = theia.window.activeTextEditor;
         if (editor) {
             editor.edit(edit => {
@@ -92,14 +95,16 @@ export function initEditorsCommands(disposables: theia.Disposable[]) {
         }
     }));
 
-    disposables.push(theia.commands.registerCommand({id:'test editor snippet', label: COMMAND_NAME_PREFIX + 'Test Editor Snippet'}, () => {
+    disposables.push(theia.commands.registerCommand(
+        { id: PLUGIN_NAME + 'test editor snippet', label: COMMAND_NAME_PREFIX + 'Test Editor Snippet' }, () => {
         const editor = theia.window.activeTextEditor;
         if (editor) {
             editor.insertSnippet(new theia.SnippetString('Hello from ${1|snippet,one,two|},current year: ${CURRENT_YEAR}\n\t${2:some}-Dir:${TM_DIRECTORY}, File:${TM_FILEPATH}$0'));
         }
     }));
 
-    disposables.push(theia.commands.registerCommand({id:'test editor decoration', label: COMMAND_NAME_PREFIX + 'Test Editor Decoration'}, () => {
+    disposables.push(theia.commands.registerCommand(
+        { id: PLUGIN_NAME + 'test editor decoration', label: COMMAND_NAME_PREFIX + 'Test Editor Decoration' }, () => {
         const editor = theia.window.activeTextEditor;
         if (editor) {
             const decoration1 = theia.window.createTextEditorDecorationType({color: 'red', textDecoration: 'underline overline dotted',cursor:'pointer',});

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -8,48 +8,51 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
+
 import * as theia from '@wiptheia/plugin';
-export function initEditorsCommands() {
+import { CONSOLE_OUTPUT_PREFIX, COMMAND_NAME_PREFIX } from './common/constants';
 
-    theia.workspace.onDidOpenTextDocument(e => {
-        console.log(`Text Document opened: ${e.uri}`);
-    });
+export function initEditorsCommands(disposables: theia.Disposable[]) {
 
-    theia.workspace.onDidCloseTextDocument( e =>{
-        console.log(`Text Document closed: ${e.uri}`);
-    });
+    disposables.push(theia.workspace.onDidOpenTextDocument(e => {
+        console.log(CONSOLE_OUTPUT_PREFIX, `Text Document opened: ${e.uri}`);
+    }));
 
-    theia.workspace.onDidChangeTextDocument( e =>{
-        if(e.contentChanges.length !== 0){
-            console.log(`Text Document Changed: 'changes: ${JSON.stringify(e.contentChanges)}', 'document: ${e.document.uri}'`);
+    disposables.push(theia.workspace.onDidCloseTextDocument(e => {
+        console.log(CONSOLE_OUTPUT_PREFIX, `Text Document closed: ${e.uri}`);
+    }));
+
+
+    disposables.push(theia.workspace.onDidChangeTextDocument(e => {
+        if(e.contentChanges.length !== 0) {
+            console.log(CONSOLE_OUTPUT_PREFIX, `Text Document Changed: 'changes: ${JSON.stringify(e.contentChanges)}', 'document: ${e.document.uri}'`);
         }
-    });
+    }));
 
-    theia.window.onDidChangeActiveTextEditor( e =>{
-        if(e){
-                    console.log(`Active Editor Changed: ${e.document.uri}`);
+    disposables.push(theia.window.onDidChangeActiveTextEditor(e => {
+        if (e) {
+            console.log(CONSOLE_OUTPUT_PREFIX, `Active Editor Changed: ${e.document.uri}`);
         } else {
-            console.log("All editors are closed");
+            console.log(CONSOLE_OUTPUT_PREFIX, 'All editors are closed');
         }
-    });
+    }));
 
-    theia.window.onDidChangeTextEditorOptions( e => {
-        console.log(`Text Editor options changed: ${e.options}`);
-    });
+    disposables.push(theia.window.onDidChangeTextEditorOptions(e => {
+        console.log(CONSOLE_OUTPUT_PREFIX, `Text Editor options changed: ${e.options}`);
+    }));
 
-    theia.window.onDidChangeTextEditorSelection(e => {
-        if(e.selections.length === 1){
+    disposables.push(theia.window.onDidChangeTextEditorSelection(e => {
+        if (e.selections.length === 1) {
             const sel = e.selections[0];
-            console.log(`Cursor position is: Ln: ${sel.end.line+1}, Col: ${sel.end.character+1}`);
+            console.log(CONSOLE_OUTPUT_PREFIX, `Cursor position is: Ln: ${sel.end.line+1}, Col: ${sel.end.character+1}`);
         }
-        
-    });
+    }));
 
-    theia.window.onDidChangeTextEditorVisibleRanges(e => {
-        console.log(`Text Editor: ${e.textEditor.document.uri} visible ranges: ${JSON.stringify(e.visibleRanges)}`);
-    });
+    disposables.push(theia.window.onDidChangeTextEditorVisibleRanges(e => {
+        console.log(CONSOLE_OUTPUT_PREFIX, `Text Editor: ${e.textEditor.document.uri} visible ranges: ${JSON.stringify(e.visibleRanges)}`);
+    }));
 
-    theia.commands.registerCommand({id: "change editor",label: "Select Editor Cursor"}, ()=>{
+    disposables.push(theia.commands.registerCommand({id: "change editor",label: COMMAND_NAME_PREFIX + "Select Editor Cursor"}, () => {
         theia.window.showQuickPick(["Block","BlockOutline", "Line", "Underline", "LineThin", "UnderlineThin" ],{placeHolder:"Select Cursor"}).then((c: string| undefined) =>{
             let cursorStyle: theia.TextEditorCursorStyle = theia.TextEditorCursorStyle.Line;
             switch(c!){
@@ -72,41 +75,40 @@ export function initEditorsCommands() {
                 cursorStyle  = theia.TextEditorCursorStyle.UnderlineThin;
                 break;
             }
-            theia.window.activeTextEditor!.options ={cursorStyle: cursorStyle};
+            theia.window.activeTextEditor!.options = { cursorStyle: cursorStyle };
         });
-    });
+    }));
 
-    theia.commands.registerCommand({id: 'reveal range test', label:'Test Reveal Range'}, ()=>{
+    disposables.push(theia.commands.registerCommand({id: 'reveal range test', label: COMMAND_NAME_PREFIX + 'Test Reveal Range'}, () => {
         theia.window.activeTextEditor!.revealRange(new theia.Range(new theia.Position(32, 4), new theia.Position(34,0)), theia.TextEditorRevealType.InCenter);
-    });
+    }));
 
-    theia.commands.registerCommand({id:'test editor edit',label:'Test EditorEdit'}, ()=>{
+    disposables.push(theia.commands.registerCommand({id:'test editor edit',label: COMMAND_NAME_PREFIX + 'Test EditorEdit'}, () => {
         const editor = theia.window.activeTextEditor;
-        if(editor){
-            editor.edit(edit=>{
+        if (editor) {
+            editor.edit(edit => {
                 edit.insert(new theia.Position(0,0),'Hello from Plugin Editor API');
             });
         }
-    });
+    }));
 
-    theia.commands.registerCommand({id:'test editor snippet', label:"Test Editor Snippet"}, ()=>{
+    disposables.push(theia.commands.registerCommand({id:'test editor snippet', label: COMMAND_NAME_PREFIX + 'Test Editor Snippet'}, () => {
         const editor = theia.window.activeTextEditor;
-        if(editor){
+        if (editor) {
             editor.insertSnippet(new theia.SnippetString('Hello from ${1|snippet,one,two|},current year: ${CURRENT_YEAR}\n\t${2:some}-Dir:${TM_DIRECTORY}, File:${TM_FILEPATH}$0'));
         }
-    });
+    }));
 
-    theia.commands.registerCommand({id:'test editor decoration', label:'Test Editor Decoration'}, ()=>{
+    disposables.push(theia.commands.registerCommand({id:'test editor decoration', label: COMMAND_NAME_PREFIX + 'Test Editor Decoration'}, () => {
         const editor = theia.window.activeTextEditor;
-        if(editor){
-            const decoration1 = theia.window.createTextEditorDecorationType({color:'red', textDecoration:'underline overline dotted',cursor:'pointer',});
+        if (editor) {
+            const decoration1 = theia.window.createTextEditorDecorationType({color: 'red', textDecoration: 'underline overline dotted',cursor:'pointer',});
             editor.setDecorations(decoration1, [new theia.Range(0,0,0,9)]);
-            const decoration2 = theia.window.createTextEditorDecorationType({color:'green'})
-            editor.setDecorations(decoration2, [{range:  new theia.Range(1,0,1,5), hoverMessage:new theia.MarkdownString('Hello From Plugin')}])
-            setTimeout(()=>{
+            const decoration2 = theia.window.createTextEditorDecorationType({color: 'green'})
+            editor.setDecorations(decoration2, [{range:  new theia.Range(1,0,1,5), hoverMessage: new theia.MarkdownString('Hello From Plugin')}])
+            setTimeout(() => {
                 decoration1.dispose();
             }, 5000);
         }
-    });
-
+    }));
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as theia from '@wiptheia/plugin';
+import { COMMAND_NAME_PREFIX } from './common/constants';
+
+export function initEnvCommands(disposables: theia.Disposable[]) {
+    const showAllQueryParametersCommand = {
+        id: 'demo-all-query-parameters-command',
+        label: COMMAND_NAME_PREFIX + 'Show All Query Parameters'
+    }
+    disposables.push(theia.commands.registerCommand(showAllQueryParametersCommand, () => {
+        theia.window.showInformationMessage(JSON.stringify(theia.env.getQueryParameters()));
+    }));
+
+    const getTestQueryParameterCommand = {
+        id: 'demo-test-query-parameter-command',
+        label: COMMAND_NAME_PREFIX + "Show Query Parameter 'test'"
+    }
+    disposables.push(theia.commands.registerCommand(getTestQueryParameterCommand, () => {
+        const test = theia.env.getQueryParameter('test');
+        theia.window.showInformationMessage(test === undefined ? 'undefined' : 'test=' + JSON.stringify(test));
+    }));
+
+    const getPathEnvVariableCommand = {
+        id: 'demo-get-path-env-var-command',
+        label: COMMAND_NAME_PREFIX + "Show Env Variable 'PATH'"
+    }
+    disposables.push(theia.commands.registerCommand(getPathEnvVariableCommand, () => {
+        theia.env.getEnvVariable('PATH').then((value: string | undefined) => {
+            theia.window.showInformationMessage(value === undefined ? 'undefined' : 'PATH=' + value, { modal: true });
+        });
+    }));
+
+    const getXEnvVariableCommand = {
+        id: 'demo-get-x-env-var-command',
+        label: COMMAND_NAME_PREFIX + "Show Env Variable 'X'"
+    }
+    disposables.push(theia.commands.registerCommand(getXEnvVariableCommand, () => {
+        theia.env.getEnvVariable('X').then((value: string | undefined) => {
+            theia.window.showInformationMessage(value === undefined ? 'undefined' : 'X=' + value, { modal: true });
+        });
+    }));
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -10,11 +10,11 @@
  */
 
 import * as theia from '@wiptheia/plugin';
-import { COMMAND_NAME_PREFIX } from './common/constants';
+import { COMMAND_NAME_PREFIX, PLUGIN_NAME } from './common/constants';
 
 export function initEnvCommands(disposables: theia.Disposable[]) {
     const showAllQueryParametersCommand = {
-        id: 'demo-all-query-parameters-command',
+        id: PLUGIN_NAME + 'all-query-parameters-command',
         label: COMMAND_NAME_PREFIX + 'Show All Query Parameters'
     }
     disposables.push(theia.commands.registerCommand(showAllQueryParametersCommand, () => {
@@ -22,7 +22,7 @@ export function initEnvCommands(disposables: theia.Disposable[]) {
     }));
 
     const getTestQueryParameterCommand = {
-        id: 'demo-test-query-parameter-command',
+        id: PLUGIN_NAME + 'test-query-parameter-command',
         label: COMMAND_NAME_PREFIX + "Show Query Parameter 'test'"
     }
     disposables.push(theia.commands.registerCommand(getTestQueryParameterCommand, () => {
@@ -31,7 +31,7 @@ export function initEnvCommands(disposables: theia.Disposable[]) {
     }));
 
     const getPathEnvVariableCommand = {
-        id: 'demo-get-path-env-var-command',
+        id: PLUGIN_NAME + 'get-path-env-var-command',
         label: COMMAND_NAME_PREFIX + "Show Env Variable 'PATH'"
     }
     disposables.push(theia.commands.registerCommand(getPathEnvVariableCommand, () => {
@@ -41,7 +41,7 @@ export function initEnvCommands(disposables: theia.Disposable[]) {
     }));
 
     const getXEnvVariableCommand = {
-        id: 'demo-get-x-env-var-command',
+        id: PLUGIN_NAME + 'get-x-env-var-command',
         label: COMMAND_NAME_PREFIX + "Show Env Variable 'X'"
     }
     disposables.push(theia.commands.registerCommand(getXEnvVariableCommand, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@
  */
 
 import * as theia from '@wiptheia/plugin';
-import { COMMAND_NAME_PREFIX, CONSOLE_OUTPUT_COMMAND_SUFIX, CONSOLE_OUTPUT_PREFIX } from './common/constants';
+import { COMMAND_NAME_PREFIX, CONSOLE_OUTPUT_COMMAND_SUFIX, CONSOLE_OUTPUT_PREFIX, PLUGIN_NAME } from './common/constants';
 import { initEditorsCommands } from './editor';
 import { initEnvCommands } from './env';
 import { initWindowStateCommands } from './window-state';
@@ -28,7 +28,7 @@ export function start() {
 
     // Hello World command
     const command: theia.Command = {
-        id: 'demo-simple-command',
+        id: PLUGIN_NAME + 'simple-command',
         label: COMMAND_NAME_PREFIX + 'Hello World command' + CONSOLE_OUTPUT_COMMAND_SUFIX
     };
     disposables.push(

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,140 +10,34 @@
  */
 
 import * as theia from '@wiptheia/plugin';
-import * as _ from 'lodash';
-import {initEditorsCommands} from './editor';
+import { COMMAND_NAME_PREFIX, CONSOLE_OUTPUT_COMMAND_SUFIX, CONSOLE_OUTPUT_PREFIX } from './common/constants';
+import { initEditorsCommands } from './editor';
+import { initEnvCommands } from './env';
+import { initWindowStateCommands } from './window-state';
+import { initQuickPickCommands } from './quick-pick';
+import { initMessagesCommands } from './messages';
+
 const disposables: theia.Disposable[] = [];
 
 export function start() {
-    initEditorsCommands();
+    initEditorsCommands(disposables);
+    initEnvCommands(disposables);
+    initWindowStateCommands(disposables);
+    initQuickPickCommands(disposables);
+    initMessagesCommands(disposables);
+
+    // Hello World command
     const command: theia.Command = {
-        id: 'simple-frontend-plugin-command',
-        label: 'Command from simple plugin'
+        id: 'demo-simple-command',
+        label: COMMAND_NAME_PREFIX + 'Hello World command' + CONSOLE_OUTPUT_COMMAND_SUFIX
     };
     disposables.push(
         theia.commands.registerCommand(command, (...args: any[]) => {
-            console.log(`>>> Simple plugin command handler was called with arguments: `, args);
-
-            if (typeof (_ as any).all === 'undefined') {
-                console.log('>>> Lodash v4 is present');
-            }
+            console.log(CONSOLE_OUTPUT_PREFIX + `Hello World command handler was called with arguments: `, args);
         })
     );
-    const quickPickTestCommand = {
-        id: 'simple-plugin-quick-pick-string-command',
-        label: "Test Quick Pick String Items"
-    }
-    disposables.push(theia.commands.registerCommand(quickPickTestCommand, (...args: any[]) => testQuickPick()));
-
-    const quickPickTestObjCommand = {
-        id: 'simple-plugin-quick-pick-object-command',
-        label: "Test Quick Pick Object Item"
-    }
-    disposables.push(theia.commands.registerCommand(quickPickTestObjCommand, (...args: any[]) => testQuickPickObject()));
-
-    const informationMessageTestCommand = {
-        id: 'frontend-plugin-information-message-command',
-        label: "Test Information Message Item"
-    };
-    disposables.push(theia.commands.registerCommand(informationMessageTestCommand, (...args: any[]) => {
-        theia.window.showInformationMessage('Information message!');
-    }));
-
-    const informationModalMessageTestCommand = {
-        id: 'frontend-plugin-information-modal-message-command',
-        label: "Test Information Modal Message Item"
-    };
-    disposables.push(theia.commands.registerCommand(informationModalMessageTestCommand, (...args: any[]) => {
-        theia.window.showInformationMessage('Information modal message!', {modal: true}, {title: 'action1'},
-            {title: 'action2', isCloseAffordance: true}, {title: 'action3'}).then(action => {
-            console.log('>>> resolve', action);
-        });
-    }));
-
-    const warningMessageTestCommand = {
-        id: 'frontend-plugin-warning-message-command',
-        label: "Test Warning Message Item"
-    };
-    disposables.push(theia.commands.registerCommand(warningMessageTestCommand, (...args: any[]) => {
-        theia.window.showWarningMessage('Warning message!');
-    }));
-
-    const warningModalMessageTestCommand = {
-        id: 'frontend-plugin-warning-modal-message-command',
-        label: "Test Warning Modal Message Item"
-    };
-    disposables.push(theia.commands.registerCommand(warningModalMessageTestCommand, (...args: any[]) => {
-        theia.window.showWarningMessage('Warning modal message!', {modal: true});
-    }));
-
-    const errorMessageTestCommand = {
-        id: 'frontend-plugin-error-message-command',
-        label: "Test Error Message Item"
-    };
-    disposables.push(theia.commands.registerCommand(errorMessageTestCommand, (...args: any[]) => {
-        theia.window.showErrorMessage('Error message!');
-    }));
-
-    const errorModalMessageTestCommand = {
-        id: 'frontend-plugin-error-modal-message-command',
-        label: "Test Error Modal Message Item"
-    };
-    disposables.push(theia.commands.registerCommand(errorModalMessageTestCommand, (...args: any[]) => {
-        theia.window.showErrorMessage('Error modal message!', {modal: true});
-    }));
-
 }
 
-function testQuickPickObject() {
-    const option: theia.QuickPickOptions = {
-        machOnDescription: true,
-        machOnDetail: true,
-        canPickMany: false,
-        placeHolder: "Select object:",
-        onDidSelectItem: (item) => console.log(`Item ${JSON.stringify(item)} is selected`)
-    };
-    theia.window.showQuickPick<theia.QuickPickItem>(new Promise((resolve)=>{
-        setTimeout(()=>{
-            resolve([
-                {
-                    label : "foo" + Math.round(Math.random()*10),
-                    description: "foo description",
-                    detail: "foo detail"
-                },
-                {
-                    label: "bar",
-                    description: "bar description",
-                    detail: "bar detail"
-                },
-                {
-                    label: "foobar",
-                    description: "foobar description",
-                    detail: "foobar detail",
-                    picked: true
-}
-            ]);
-        }, 500);
-    }), option).then((val: theia.QuickPickItem| undefined) => {
-        console.log(`Quick Pick Object Selected: ${JSON.stringify(val)}`);
-    });
-}
-
-function testQuickPick(): void {
-    const option: theia.QuickPickOptions = {
-        machOnDescription: true,
-        machOnDetail: true,
-        canPickMany: false,
-        placeHolder: "Select string:",
-        onDidSelectItem: (item) => console.log(`Item ${item} is selected`)
-    };
-    theia.window.showQuickPick(new Promise((resolve)=>{
-        setTimeout(()=>{
-            resolve(["foo" + Math.round(Math.random()*10), "bar", "foobar"]);
-        }, 500);
-    }), option).then((val: string | undefined) => {
-        console.log(`Quick Pick Selected: ${val}`);
-    });
-}
 export function stop() {
     while (disposables.length) {
         const disposable = disposables.pop();
@@ -152,4 +46,3 @@ export function stop() {
         }
     }
 }
-

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -10,11 +10,11 @@
  */
 
 import * as theia from '@wiptheia/plugin';
-import { COMMAND_NAME_PREFIX, CONSOLE_OUTPUT_PREFIX } from './common/constants';
+import { COMMAND_NAME_PREFIX, CONSOLE_OUTPUT_PREFIX, PLUGIN_NAME } from './common/constants';
 
 export function initMessagesCommands(disposables: theia.Disposable[]) {
     const informationMessageTestCommand = {
-        id: 'frontend-plugin-information-message-command',
+        id: PLUGIN_NAME + 'information-message-command',
         label: COMMAND_NAME_PREFIX + 'Information Message'
     };
     disposables.push(theia.commands.registerCommand(informationMessageTestCommand, (...args: any[]) => {
@@ -22,7 +22,7 @@ export function initMessagesCommands(disposables: theia.Disposable[]) {
     }));
 
     const informationModalMessageTestCommand = {
-        id: 'frontend-plugin-information-modal-message-command',
+        id: PLUGIN_NAME + 'information-modal-message-command',
         label: COMMAND_NAME_PREFIX + 'Information Modal Message'
     };
     disposables.push(theia.commands.registerCommand(informationModalMessageTestCommand, (...args: any[]) => {
@@ -33,7 +33,7 @@ export function initMessagesCommands(disposables: theia.Disposable[]) {
     }));
 
     const warningMessageTestCommand = {
-        id: 'frontend-plugin-warning-message-command',
+        id: PLUGIN_NAME + 'warning-message-command',
         label: COMMAND_NAME_PREFIX + 'Warning Message'
     };
     disposables.push(theia.commands.registerCommand(warningMessageTestCommand, (...args: any[]) => {
@@ -41,7 +41,7 @@ export function initMessagesCommands(disposables: theia.Disposable[]) {
     }));
 
     const warningModalMessageTestCommand = {
-        id: 'frontend-plugin-warning-modal-message-command',
+        id: PLUGIN_NAME + 'warning-modal-message-command',
         label: COMMAND_NAME_PREFIX + 'Warning Modal Message'
     };
     disposables.push(theia.commands.registerCommand(warningModalMessageTestCommand, (...args: any[]) => {
@@ -49,7 +49,7 @@ export function initMessagesCommands(disposables: theia.Disposable[]) {
     }));
 
     const errorMessageTestCommand = {
-        id: 'frontend-plugin-error-message-command',
+        id: PLUGIN_NAME + 'error-message-command',
         label: COMMAND_NAME_PREFIX + 'Error Message'
     };
     disposables.push(theia.commands.registerCommand(errorMessageTestCommand, (...args: any[]) => {
@@ -57,7 +57,7 @@ export function initMessagesCommands(disposables: theia.Disposable[]) {
     }));
 
     const errorModalMessageTestCommand = {
-        id: 'frontend-plugin-error-modal-message-command',
+        id: PLUGIN_NAME + 'error-modal-message-command',
         label: COMMAND_NAME_PREFIX + 'Error Modal Message'
     };
     disposables.push(theia.commands.registerCommand(errorModalMessageTestCommand, (...args: any[]) => {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as theia from '@wiptheia/plugin';
+import { COMMAND_NAME_PREFIX, CONSOLE_OUTPUT_PREFIX } from './common/constants';
+
+export function initMessagesCommands(disposables: theia.Disposable[]) {
+    const informationMessageTestCommand = {
+        id: 'frontend-plugin-information-message-command',
+        label: COMMAND_NAME_PREFIX + 'Information Message'
+    };
+    disposables.push(theia.commands.registerCommand(informationMessageTestCommand, (...args: any[]) => {
+        theia.window.showInformationMessage('Information message!');
+    }));
+
+    const informationModalMessageTestCommand = {
+        id: 'frontend-plugin-information-modal-message-command',
+        label: COMMAND_NAME_PREFIX + 'Information Modal Message'
+    };
+    disposables.push(theia.commands.registerCommand(informationModalMessageTestCommand, (...args: any[]) => {
+        theia.window.showInformationMessage('Information modal message!', { modal: true },
+            { title: 'action1' }, { title: 'action2', isCloseAffordance: true }, { title: 'action3' }).then(action => {
+            console.log(CONSOLE_OUTPUT_PREFIX, 'Resolve', action);
+        });
+    }));
+
+    const warningMessageTestCommand = {
+        id: 'frontend-plugin-warning-message-command',
+        label: COMMAND_NAME_PREFIX + 'Warning Message'
+    };
+    disposables.push(theia.commands.registerCommand(warningMessageTestCommand, (...args: any[]) => {
+        theia.window.showWarningMessage('Warning message!');
+    }));
+
+    const warningModalMessageTestCommand = {
+        id: 'frontend-plugin-warning-modal-message-command',
+        label: COMMAND_NAME_PREFIX + 'Warning Modal Message'
+    };
+    disposables.push(theia.commands.registerCommand(warningModalMessageTestCommand, (...args: any[]) => {
+        theia.window.showWarningMessage('Warning modal message!', { modal: true} );
+    }));
+
+    const errorMessageTestCommand = {
+        id: 'frontend-plugin-error-message-command',
+        label: COMMAND_NAME_PREFIX + 'Error Message'
+    };
+    disposables.push(theia.commands.registerCommand(errorMessageTestCommand, (...args: any[]) => {
+        theia.window.showErrorMessage('Error message!');
+    }));
+
+    const errorModalMessageTestCommand = {
+        id: 'frontend-plugin-error-modal-message-command',
+        label: COMMAND_NAME_PREFIX + 'Error Modal Message'
+    };
+    disposables.push(theia.commands.registerCommand(errorModalMessageTestCommand, (...args: any[]) => {
+        theia.window.showErrorMessage('Error modal message!', { modal: true });
+    }));
+}

--- a/src/quick-pick.ts
+++ b/src/quick-pick.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2018-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as theia from '@wiptheia/plugin';
+import { COMMAND_NAME_PREFIX, CONSOLE_OUTPUT_COMMAND_SUFIX, CONSOLE_OUTPUT_PREFIX } from './common/constants';
+
+export function initQuickPickCommands(disposables: theia.Disposable[]) {
+    const quickPickTestCommand = {
+        id: 'demo-quick-pick-string-command',
+        label: COMMAND_NAME_PREFIX + 'Quick Pick String Items' + CONSOLE_OUTPUT_COMMAND_SUFIX
+    }
+    disposables.push(theia.commands.registerCommand(quickPickTestCommand, (...args: any[]) => testQuickPick()));
+
+    const quickPickTestObjCommand = {
+        id: 'demo-quick-pick-object-command',
+        label: COMMAND_NAME_PREFIX + 'Quick Pick Object Item' + CONSOLE_OUTPUT_COMMAND_SUFIX
+    }
+    disposables.push(theia.commands.registerCommand(quickPickTestObjCommand, (...args: any[]) => testQuickPickObject()));
+}
+
+function testQuickPick(): void {
+    const option: theia.QuickPickOptions = {
+        machOnDescription: true,
+        machOnDetail: true,
+        canPickMany: false,
+        placeHolder: "Select string:",
+        onDidSelectItem: (item) => console.log(CONSOLE_OUTPUT_PREFIX, `Item ${item} is selected`)
+    };
+    theia.window.showQuickPick(new Promise((resolve)=>{
+        setTimeout(()=>{
+            resolve(["foo" + Math.round(Math.random()*10), "bar", "foobar"]);
+        }, 500);
+    }), option).then((val: string | undefined) => {
+        console.log(CONSOLE_OUTPUT_PREFIX, `Quick Pick Selected: ${val}`);
+    });
+}
+
+function testQuickPickObject() {
+    const option: theia.QuickPickOptions = {
+        machOnDescription: true,
+        machOnDetail: true,
+        canPickMany: false,
+        placeHolder: "Select object:",
+        onDidSelectItem: (item) => console.log(`Item ${JSON.stringify(item)} is selected`)
+    };
+    theia.window.showQuickPick<theia.QuickPickItem>(new Promise((resolve)=>{
+        setTimeout(()=>{
+            resolve([
+                {
+                    label : "foo" + Math.round(Math.random()*10),
+                    description: "foo description",
+                    detail: "foo detail"
+                },
+                {
+                    label: "bar",
+                    description: "bar description",
+                    detail: "bar detail"
+                },
+                {
+                    label: "foobar",
+                    description: "foobar description",
+                    detail: "foobar detail",
+                    picked: true
+}
+            ]);
+        }, 500);
+    }), option).then((val: theia.QuickPickItem| undefined) => {
+        console.log(CONSOLE_OUTPUT_PREFIX, `Quick Pick Object Selected: ${JSON.stringify(val)}`);
+    });
+}

--- a/src/quick-pick.ts
+++ b/src/quick-pick.ts
@@ -10,17 +10,17 @@
  */
 
 import * as theia from '@wiptheia/plugin';
-import { COMMAND_NAME_PREFIX, CONSOLE_OUTPUT_COMMAND_SUFIX, CONSOLE_OUTPUT_PREFIX } from './common/constants';
+import { COMMAND_NAME_PREFIX, CONSOLE_OUTPUT_COMMAND_SUFIX, CONSOLE_OUTPUT_PREFIX, PLUGIN_NAME } from './common/constants';
 
 export function initQuickPickCommands(disposables: theia.Disposable[]) {
     const quickPickTestCommand = {
-        id: 'demo-quick-pick-string-command',
+        id: PLUGIN_NAME + 'quick-pick-string-command',
         label: COMMAND_NAME_PREFIX + 'Quick Pick String Items' + CONSOLE_OUTPUT_COMMAND_SUFIX
     }
     disposables.push(theia.commands.registerCommand(quickPickTestCommand, (...args: any[]) => testQuickPick()));
 
     const quickPickTestObjCommand = {
-        id: 'demo-quick-pick-object-command',
+        id: PLUGIN_NAME + 'quick-pick-object-command',
         label: COMMAND_NAME_PREFIX + 'Quick Pick Object Item' + CONSOLE_OUTPUT_COMMAND_SUFIX
     }
     disposables.push(theia.commands.registerCommand(quickPickTestObjCommand, (...args: any[]) => testQuickPickObject()));
@@ -69,7 +69,7 @@ function testQuickPickObject() {
                     description: "foobar description",
                     detail: "foobar detail",
                     picked: true
-}
+                }
             ]);
         }, 500);
     }), option).then((val: theia.QuickPickItem| undefined) => {

--- a/src/window-state.ts
+++ b/src/window-state.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as theia from '@wiptheia/plugin';
+import { COMMAND_NAME_PREFIX, CONSOLE_OUTPUT_COMMAND_SUFIX, CONSOLE_OUTPUT_PREFIX } from './common/constants';
+
+export function initWindowStateCommands(disposables: theia.Disposable[]) {
+    const showStateCommand: theia.Command = {
+        id: 'demo-show-window-state',
+        label: COMMAND_NAME_PREFIX + 'Window State' + CONSOLE_OUTPUT_COMMAND_SUFIX
+    };
+    disposables.push(
+        theia.commands.registerCommand(showStateCommand, (...args: any[]) => {
+            console.log(CONSOLE_OUTPUT_PREFIX, 'Window state: ', theia.window.state);
+        })
+    );
+
+    const showStateWithDelayCommand: theia.Command = {
+        id: 'demo-show-window-state-delayed',
+        label: COMMAND_NAME_PREFIX + 'Window State After 2.5 seconds' + CONSOLE_OUTPUT_COMMAND_SUFIX
+    };
+    disposables.push(
+        theia.commands.registerCommand(showStateWithDelayCommand, (...args: any[]) => {
+            setTimeout(() => console.log(CONSOLE_OUTPUT_PREFIX, 'Window state: ', theia.window.state), 2500);
+        })
+    );
+
+    disposables.push(
+        theia.window.onDidChangeWindowState((windowState: theia.WindowState) => {
+            console.log(CONSOLE_OUTPUT_PREFIX, 'Window focus: ', windowState.focused);
+        })
+    );
+}

--- a/src/window-state.ts
+++ b/src/window-state.ts
@@ -10,11 +10,11 @@
  */
 
 import * as theia from '@wiptheia/plugin';
-import { COMMAND_NAME_PREFIX, CONSOLE_OUTPUT_COMMAND_SUFIX, CONSOLE_OUTPUT_PREFIX } from './common/constants';
+import { COMMAND_NAME_PREFIX, CONSOLE_OUTPUT_COMMAND_SUFIX, CONSOLE_OUTPUT_PREFIX, PLUGIN_NAME } from './common/constants';
 
 export function initWindowStateCommands(disposables: theia.Disposable[]) {
     const showStateCommand: theia.Command = {
-        id: 'demo-show-window-state',
+        id: PLUGIN_NAME + 'show-window-state',
         label: COMMAND_NAME_PREFIX + 'Window State' + CONSOLE_OUTPUT_COMMAND_SUFIX
     };
     disposables.push(
@@ -24,7 +24,7 @@ export function initWindowStateCommands(disposables: theia.Disposable[]) {
     );
 
     const showStateWithDelayCommand: theia.Command = {
-        id: 'demo-show-window-state-delayed',
+        id: PLUGIN_NAME + 'show-window-state-delayed',
         label: COMMAND_NAME_PREFIX + 'Window State After 2.5 seconds' + CONSOLE_OUTPUT_COMMAND_SUFIX
     };
     disposables.push(


### PR DESCRIPTION
This PR refactors sample plugin structure in the following way:
 - examples of each API section are separated into corresponding files.
 - introduces `Demo: ` prefix for each sample command name
 - introduces plugin name prefix for commands IDs to avoid name collisions.
 - introduces ` (console)` suffix for each sample command name if the command prints into developer console.
 - introduces `>>>> ` console output prefix to distinguish sample commands output from other logs.

Also adds window-state API from separate repository and adds new env API samples.

Signed-off-by: Mykola Morhun <mmorhun@redhat.com>